### PR TITLE
feat(SAPIC-10): Backend Git Auth Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ dist/
 .idea
 .idea/**
 /crates/moss-wasmhost/wasm/target
+/crates/moss-git/src/secrets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,17 +2515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moss-git"
-version = "0.1.0"
-dependencies = [
- "git2",
- "oauth2",
- "openssl",
- "reqwest",
- "ssh2",
-]
-
-[[package]]
 name = "moss_desktop"
 version = "0.1.0"
 dependencies = [
@@ -2537,6 +2526,17 @@ dependencies = [
  "serde",
  "tauri",
  "ts-rs",
+]
+
+[[package]]
+name = "moss_git"
+version = "0.1.0"
+dependencies = [
+ "git2",
+ "oauth2",
+ "openssl",
+ "reqwest",
+ "ssh2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,8 @@ version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -639,8 +641,10 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -693,9 +697,9 @@ dependencies = [
  "bitflags 2.8.0",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -708,7 +712,7 @@ checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
 dependencies = [
  "bitflags 2.8.0",
  "block",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
  "libc",
  "objc",
@@ -767,6 +771,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
@@ -788,9 +802,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -801,7 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "libc",
 ]
 
@@ -1141,6 +1155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,12 +1273,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1268,6 +1300,12 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1605,6 +1643,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1791,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.7.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,6 +1911,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1865,6 +1938,22 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2165,6 +2254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,6 +2331,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.0+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2362,32 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2377,6 +2515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "moss-git"
+version = "0.1.0"
+dependencies = [
+ "git2",
+ "oauth2",
+ "openssl",
+ "reqwest",
+ "ssh2",
+]
+
+[[package]]
 name = "moss_desktop"
 version = "0.1.0"
 dependencies = [
@@ -2425,6 +2574,23 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2522,6 +2688,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.15",
+ "http",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -2765,6 +2951,60 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "openssl"
+version = "0.10.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-src"
+version = "300.4.2+3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3438,18 +3678,23 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3461,7 +3706,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3634,6 +3881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,6 +3927,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3752,6 +4031,16 @@ dependencies = [
  "itoa 1.0.14",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa 1.0.14",
  "serde",
 ]
 
@@ -3959,7 +4248,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2",
@@ -4003,6 +4292,18 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "ssh2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "libssh2-sys",
+ "parking_lot",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -4132,6 +4433,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,7 +4474,7 @@ checksum = "3731d04d4ac210cd5f344087733943b9bfb1a32654387dad4d1c70de21aee2c9"
 dependencies = [
  "bitflags 2.8.0",
  "cocoa",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -4520,6 +4842,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4680,6 +5016,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5046,6 +5392,12 @@ name = "value-bag"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "1"
 members = [
     "crates/moss-desktop",
+    "crates/moss-git",
     "crates/moss-tauri",
     "crates/moss-text",
     "tools/xtask",
@@ -12,6 +13,7 @@ members = [
 moss_desktop = { path = "crates/moss-desktop" }
 moss_tauri = { path = "crates/moss-tauri" }
 moss_text = { path = "crates/moss-text" }
+moss_git = { path = "crates/moss-git" }
 
 tauri = { version = "2.2.5", default-features = false }
 
@@ -22,12 +24,16 @@ clap = { version = "4.5.28", features = ["derive"] }
 derive_more = "2.0.1"
 dirs = "6.0.0"
 fnv = "1.0.7"
+git2 = "0.20.0"
 log = "0.4.25"
+oauth2 = "5.0.0"
 once_cell = "1.20.3"
 parking_lot = "0.12.3"
 rand = { version = "0.9.0", default-features = false, features = ["thread_rng"]}
+reqwest = "0.12.12"
 serde = "1.0.217"
 serde_json = "1.0.138"
+ssh2 = "0.9.5"
 strum = "0.27.0"
 tokio = "1.43.0"
 tracing = "0.1"

--- a/crates/moss-git/Cargo.toml
+++ b/crates/moss-git/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "moss-git"
+name = "moss_git"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/moss-git/Cargo.toml
+++ b/crates/moss-git/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "moss-git"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+git2.workspace = true
+oauth2 = { workspace = true, features = ["reqwest-blocking"] }
+reqwest = { workspace = true, features = ["blocking"] } # Using blocking for easy testing here
+
+# Making SSH work on Windows
+[target.'cfg(windows)'.dependencies]
+openssl = { version = "0.10.70", features = ["vendored"] }
+ssh2 = { workspace = true, features = ["openssl-on-win32", "vendored-openssl"] }

--- a/crates/moss-git/src/lib.rs
+++ b/crates/moss-git/src/lib.rs
@@ -10,15 +10,6 @@ use oauth2::basic::BasicClient;
 use oauth2::reqwest;
 use oauth2::url::Url;
 
-fn prompt_credentials() -> (String, String) {
-    println!("Please enter username: ");
-    let mut username = String::new();
-    stdin().read_line(&mut username).unwrap();
-    println!("Please enter password: ");
-    let mut password = String::new();
-    stdin().read_line(&mut password).unwrap();
-    (username, password)
-}
 mod test {
 
     use super::*;
@@ -52,8 +43,6 @@ mod test {
         if let repo = clone_flow(repo_url, repo_path, callbacks) {
             println!("The repo is successfully cloned using https.");
         }
-
-
     }
 
     // Some extra setup needs to be done before using SSH on Windows
@@ -185,5 +174,7 @@ mod test {
             println!("The repo is successfully cloned using OAuth Git");
         }
     }
+
+
 }
 

--- a/crates/moss-git/src/lib.rs
+++ b/crates/moss-git/src/lib.rs
@@ -1,21 +1,22 @@
-use git2::{Repository, Cred, Config};
-use git2::build::RepoBuilder;
-use std::fs::remove_dir_all;
-use std::io::{stdin, BufRead, BufReader, Write};
-use std::net::TcpListener;
-use std::path::Path;
-use git2::{RemoteCallbacks};
-use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope, TokenResponse, TokenUrl};
-use oauth2::basic::BasicClient;
-use oauth2::reqwest;
-use oauth2::url::Url;
-
-mod test {
-
-    use super::*;
+#[cfg(test)]
+mod tests {
+    use git2::build::RepoBuilder;
+    use git2::RemoteCallbacks;
+    use git2::{Config, Cred, Repository};
+    use oauth2::basic::BasicClient;
+    use oauth2::reqwest;
+    use oauth2::url::Url;
+    use oauth2::{
+        AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope,
+        TokenResponse, TokenUrl,
+    };
+    use std::fs::remove_dir_all;
+    use std::io::{stdin, BufRead, BufReader, Write};
+    use std::net::TcpListener;
+    use std::path::Path;
 
     fn clone_flow(url: &str, path: &Path, callback: RemoteCallbacks) -> Result<Repository, String> {
-        remove_dir_all(path);
+        // remove_dir_all(path);
 
         let mut fo = git2::FetchOptions::new();
         fo.remote_callbacks(callback);
@@ -27,7 +28,6 @@ mod test {
             Ok(repo) => Ok(repo),
             Err(e) => Err(format!("failed to clone: {}", e)),
         }
-
     }
     #[test]
     fn cloning_with_https() {
@@ -69,7 +69,6 @@ mod test {
         }
     }
 
-
     // Run cargo test cloning_with_oauth_github -- --nocapture
     #[test]
     fn cloning_with_oauth_github() {
@@ -93,7 +92,8 @@ mod test {
             // This example will be running its own server at localhost:8080.
             // See below for the server implementation.
             .set_redirect_uri(
-                RedirectUrl::new(format!("http://localhost:{}", callback_port)).expect("Invalid redirect URL"),
+                RedirectUrl::new(format!("http://localhost:{}", callback_port))
+                    .expect("Invalid redirect URL"),
             );
 
         let http_client = reqwest::blocking::ClientBuilder::new()
@@ -108,7 +108,6 @@ mod test {
             // This example is requesting access to the user's public repos and private repos
             .add_scope(Scope::new("repo".to_string()))
             .url();
-
 
         println!("Open this URL in your browser:\n{authorize_url}\n");
         let (code, state) = {
@@ -174,7 +173,4 @@ mod test {
             println!("The repo is successfully cloned using OAuth Git");
         }
     }
-
-
 }
-

--- a/crates/moss-git/src/lib.rs
+++ b/crates/moss-git/src/lib.rs
@@ -1,0 +1,189 @@
+use git2::{Repository, Cred, Config};
+use git2::build::RepoBuilder;
+use std::fs::remove_dir_all;
+use std::io::{stdin, BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use git2::{RemoteCallbacks};
+use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope, TokenResponse, TokenUrl};
+use oauth2::basic::BasicClient;
+use oauth2::reqwest;
+use oauth2::url::Url;
+
+fn prompt_credentials() -> (String, String) {
+    println!("Please enter username: ");
+    let mut username = String::new();
+    stdin().read_line(&mut username).unwrap();
+    println!("Please enter password: ");
+    let mut password = String::new();
+    stdin().read_line(&mut password).unwrap();
+    (username, password)
+}
+mod test {
+
+    use super::*;
+
+    fn clone_flow(url: &str, path: &Path, callback: RemoteCallbacks) -> Result<Repository, String> {
+        remove_dir_all(path);
+
+        let mut fo = git2::FetchOptions::new();
+        fo.remote_callbacks(callback);
+
+        let mut builder = RepoBuilder::new();
+        builder.fetch_options(fo);
+
+        match builder.clone(url, path) {
+            Ok(repo) => Ok(repo),
+            Err(e) => Err(format!("failed to clone: {}", e)),
+        }
+
+    }
+    #[test]
+    fn cloning_with_https() {
+        let repo_url = "https://github.com/***.git";
+        let repo_path = Path::new("Local Path");
+
+        let mut callbacks = git2::RemoteCallbacks::new();
+        callbacks.credentials(move |url, username_from_url, _allowed_types| {
+            let default_config = Config::open_default().unwrap();
+            Cred::credential_helper(&default_config, url, username_from_url)
+        });
+
+        if let repo = clone_flow(repo_url, repo_path, callbacks) {
+            println!("The repo is successfully cloned using https.");
+        }
+
+
+    }
+
+    // Some extra setup needs to be done before using SSH on Windows
+    // https://github.com/rust-lang/git2-rs/issues/659
+    // https://github.com/rust-lang/git2-rs/issues/1106
+    // https://stackoverflow.com/questions/72062352/issue-running-openssl-on-windows
+    // For vcpkg, run .\bootstrap-vcpkg.bat
+    #[test]
+    fn cloning_with_ssh() {
+        let repo_url = "git@github.com:***/***";
+        let repo_path = Path::new("Local Path");
+
+        let private = Path::new(".ssh/id_***");
+        let public = Path::new(".ssh/id_***.pub");
+        let password = "PASSWORD";
+
+        let mut callbacks = git2::RemoteCallbacks::new();
+        callbacks.credentials(move |url, username_from_url, _allowed_types| {
+            Cred::ssh_key("git", Some(public), private, Some(password))
+        });
+
+        if let repo = clone_flow(repo_url, repo_path, callbacks) {
+            println!("The repo is successfully cloned using ssh.");
+        }
+    }
+
+
+    // Run cargo test cloning_with_oauth_github -- --nocapture
+    #[test]
+    fn cloning_with_oauth_github() {
+        // From example: https://github.com/ramosbugs/oauth2-rs/blob/main/examples/github.rs
+        let repo_url = "https://github.com/***.git";
+        let repo_path = Path::new("Local Path");
+
+        let github_client_id = "ID";
+        let github_client_secret = "Secret";
+        let callback_port = "1357";
+
+        let auth_url = AuthUrl::new("https://github.com/login/oauth/authorize".to_string())
+            .expect("Invalid authorization endpoint URL");
+        let token_url = TokenUrl::new("https://github.com/login/oauth/access_token".to_string())
+            .expect("Invalid token endpoint URL");
+
+        let client = BasicClient::new(ClientId::new(github_client_id.into()))
+            .set_client_secret(ClientSecret::new(github_client_secret.into()))
+            .set_auth_uri(auth_url)
+            .set_token_uri(token_url)
+            // This example will be running its own server at localhost:8080.
+            // See below for the server implementation.
+            .set_redirect_uri(
+                RedirectUrl::new(format!("http://localhost:{}", callback_port)).expect("Invalid redirect URL"),
+            );
+
+        let http_client = reqwest::blocking::ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("Client should build");
+
+        // Generate the authorization URL to which we'll redirect the user.
+        let (authorize_url, csrf_state) = client
+            .authorize_url(CsrfToken::new_random)
+            // This example is requesting access to the user's public repos and private repos
+            .add_scope(Scope::new("repo".to_string()))
+            .url();
+
+
+        println!("Open this URL in your browser:\n{authorize_url}\n");
+        let (code, state) = {
+            // A very naive implementation of the redirect server.
+            let listener = TcpListener::bind(format!("localhost:{}", callback_port)).unwrap();
+
+            // The server will terminate itself after collecting the first code.
+            let Some(mut stream) = listener.incoming().flatten().next() else {
+                panic!("listener terminated without accepting a connection");
+            };
+
+            let mut reader = BufReader::new(&stream);
+
+            let mut request_line = String::new();
+            reader.read_line(&mut request_line).unwrap();
+
+            let redirect_url = request_line.split_whitespace().nth(1).unwrap();
+            let url = Url::parse(&("http://localhost".to_string() + redirect_url)).unwrap();
+
+            let code = url
+                .query_pairs()
+                .find(|(key, _)| key == "code")
+                .map(|(_, code)| AuthorizationCode::new(code.into_owned()))
+                .unwrap();
+
+            let state = url
+                .query_pairs()
+                .find(|(key, _)| key == "state")
+                .map(|(_, state)| CsrfToken::new(state.into_owned()))
+                .unwrap();
+
+            let message = "Go back to your terminal :)";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\n\r\n{}",
+                message.len(),
+                message
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+
+            (code, state)
+        };
+
+        println!("Github returned the following code:\n{}\n", code.secret());
+        println!(
+            "Github returned the following state:\n{} (expected `{}`)\n",
+            state.secret(),
+            csrf_state.secret()
+        );
+
+        // Exchange the code with a token.
+        let token_res = client.exchange_code(code).request(&http_client).unwrap();
+
+        println!("Github returned the following token:\n{token_res:?}\n");
+
+        let access_token = token_res.access_token();
+
+        let mut callbacks = git2::RemoteCallbacks::new();
+        callbacks.credentials(move |url, username_from_url, _allowed_types| {
+            Cred::userpass_plaintext("oauth2", access_token.secret())
+        });
+
+        if let repo = clone_flow(repo_url, repo_path, callbacks) {
+            println!("The repo is successfully cloned using OAuth Git");
+        }
+    }
+}
+

--- a/crates/moss-git/src/lib.rs
+++ b/crates/moss-git/src/lib.rs
@@ -39,9 +39,8 @@ mod github_tests {
         let token_url = "https://github.com/login/oauth/access_token";
         let client_id = "***";
         let client_secret = "***";
-        let callback_port = "1357";
 
-        let github_oauth = OAuth::new(auth_url, token_url, client_id, client_secret, callback_port);
+        let github_oauth = OAuth::new(auth_url, token_url, client_id, client_secret);
         let mut callbacks = git2::RemoteCallbacks::new();
 
         github_oauth.flow(&mut callbacks);

--- a/crates/moss-git/src/lib.rs
+++ b/crates/moss-git/src/lib.rs
@@ -40,16 +40,10 @@ mod tests {
             Cred::credential_helper(&default_config, url, username_from_url)
         });
 
-        if let repo = clone_flow(repo_url, repo_path, callbacks) {
-            println!("The repo is successfully cloned using https.");
-        }
-    }
+        let repo = clone_flow(repo_url, repo_path, callbacks).unwrap();
 
-    // Some extra setup needs to be done before using SSH on Windows
-    // https://github.com/rust-lang/git2-rs/issues/659
-    // https://github.com/rust-lang/git2-rs/issues/1106
-    // https://stackoverflow.com/questions/72062352/issue-running-openssl-on-windows
-    // For vcpkg, run .\bootstrap-vcpkg.bat
+    }
+    
     #[test]
     fn cloning_with_ssh() {
         let repo_url = "git@github.com:***/***";
@@ -64,9 +58,7 @@ mod tests {
             Cred::ssh_key("git", Some(public), private, Some(password))
         });
 
-        if let repo = clone_flow(repo_url, repo_path, callbacks) {
-            println!("The repo is successfully cloned using ssh.");
-        }
+        let repo = clone_flow(repo_url, repo_path, callbacks).unwrap();
     }
 
     // Run cargo test cloning_with_oauth_github -- --nocapture
@@ -169,8 +161,6 @@ mod tests {
             Cred::userpass_plaintext("oauth2", access_token.secret())
         });
 
-        if let repo = clone_flow(repo_url, repo_path, callbacks) {
-            println!("The repo is successfully cloned using OAuth Git");
-        }
+        let repo = clone_flow(repo_url, repo_path, callbacks).unwrap();
     }
 }

--- a/crates/moss-git/src/lib.rs
+++ b/crates/moss-git/src/lib.rs
@@ -1,38 +1,80 @@
-#[cfg(test)]
-mod tests {
-    use git2::build::RepoBuilder;
-    use git2::RemoteCallbacks;
-    use git2::{Config, Cred, Repository};
-    use oauth2::basic::BasicClient;
-    use oauth2::reqwest;
-    use oauth2::url::Url;
-    use oauth2::{
-        AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope,
-        TokenResponse, TokenUrl,
-    };
-    use std::fs::remove_dir_all;
-    use std::io::{stdin, BufRead, BufReader, Write};
-    use std::net::TcpListener;
-    use std::path::Path;
+pub mod oauth;
 
-    fn clone_flow(url: &str, path: &Path, callback: RemoteCallbacks) -> Result<Repository, String> {
-        // remove_dir_all(path);
+use git2::build::RepoBuilder;
+use git2::RemoteCallbacks;
+use git2::{Config, Cred, Repository};
+use oauth2::TokenResponse;
+use std::io::{BufRead, Write};
+use std::path::Path;
 
-        let mut fo = git2::FetchOptions::new();
-        fo.remote_callbacks(callback);
+fn clone_flow(url: &str, path: &Path, callback: RemoteCallbacks) -> Result<Repository, String> {
+    // remove_dir_all(path);
 
-        let mut builder = RepoBuilder::new();
-        builder.fetch_options(fo);
+    let mut fo = git2::FetchOptions::new();
+    fo.remote_callbacks(callback);
 
-        match builder.clone(url, path) {
-            Ok(repo) => Ok(repo),
-            Err(e) => Err(format!("failed to clone: {}", e)),
-        }
+    let mut builder = RepoBuilder::new();
+    builder.fetch_options(fo);
+
+    match builder.clone(url, path) {
+        Ok(repo) => Ok(repo),
+        Err(e) => Err(format!("failed to clone: {}", e)),
     }
+}
+
+
+#[cfg(test)]
+mod github_tests {
+    use crate::oauth::OAuth;
+    use super::*;
+
+    // Run cargo test cloning_with_https -- --nocapture
     #[test]
     fn cloning_with_https() {
-        let repo_url = "https://github.com/***.git";
-        let repo_path = Path::new("Local Path");
+        // From example: https://github.com/ramosbugs/oauth2-rs/blob/main/examples/github.rs
+        let repo_url = "https://github.com/**/**.git";
+        let repo_path = Path::new("Path to your local repo");
+
+        let auth_url = "https://github.com/login/oauth/authorize";
+        let token_url = "https://github.com/login/oauth/access_token";
+        let client_id = "***";
+        let client_secret = "***";
+        let callback_port = "1357";
+
+        let github_oauth = OAuth::new(auth_url, token_url, client_id, client_secret, callback_port);
+        let mut callbacks = git2::RemoteCallbacks::new();
+
+        github_oauth.flow(&mut callbacks);
+
+        let repo = clone_flow(repo_url, repo_path, callbacks).unwrap();
+    }
+
+    #[test]
+    fn cloning_with_ssh() {
+        let repo_url = "git@github.com:***/***";
+        let repo_path = Path::new("Path to your local repo");
+
+        let private = Path::new(".ssh/id_***");
+        let public = Path::new(".ssh/id_***.pub");
+        let password = "**";
+
+        let mut callbacks = git2::RemoteCallbacks::new();
+        callbacks.credentials(move |url, username_from_url, _allowed_types| {
+            Cred::ssh_key("git", Some(public), private, Some(password))
+        });
+
+        let repo = clone_flow(repo_url, repo_path, callbacks).unwrap();
+    }
+
+}
+
+#[cfg(test)]
+mod gitlab_tests {
+    use super::*;
+    #[test]
+    fn cloning_with_https() {
+        let repo_url = "https://gitlab.com/**/**.git";
+        let repo_path = Path::new("Path to your local repo");
 
         let mut callbacks = git2::RemoteCallbacks::new();
         callbacks.credentials(move |url, username_from_url, _allowed_types| {
@@ -43,15 +85,15 @@ mod tests {
         let repo = clone_flow(repo_url, repo_path, callbacks).unwrap();
 
     }
-    
+
     #[test]
     fn cloning_with_ssh() {
-        let repo_url = "git@github.com:***/***";
-        let repo_path = Path::new("Local Path");
+        let repo_url = "git@gitlab.com:**/**.git";
+        let repo_path = Path::new("test-repo");
 
         let private = Path::new(".ssh/id_***");
         let public = Path::new(".ssh/id_***.pub");
-        let password = "PASSWORD";
+        let password = "**";
 
         let mut callbacks = git2::RemoteCallbacks::new();
         callbacks.credentials(move |url, username_from_url, _allowed_types| {
@@ -61,106 +103,5 @@ mod tests {
         let repo = clone_flow(repo_url, repo_path, callbacks).unwrap();
     }
 
-    // Run cargo test cloning_with_oauth_github -- --nocapture
-    #[test]
-    fn cloning_with_oauth_github() {
-        // From example: https://github.com/ramosbugs/oauth2-rs/blob/main/examples/github.rs
-        let repo_url = "https://github.com/***.git";
-        let repo_path = Path::new("Local Path");
 
-        let github_client_id = "ID";
-        let github_client_secret = "Secret";
-        let callback_port = "1357";
-
-        let auth_url = AuthUrl::new("https://github.com/login/oauth/authorize".to_string())
-            .expect("Invalid authorization endpoint URL");
-        let token_url = TokenUrl::new("https://github.com/login/oauth/access_token".to_string())
-            .expect("Invalid token endpoint URL");
-
-        let client = BasicClient::new(ClientId::new(github_client_id.into()))
-            .set_client_secret(ClientSecret::new(github_client_secret.into()))
-            .set_auth_uri(auth_url)
-            .set_token_uri(token_url)
-            // This example will be running its own server at localhost:8080.
-            // See below for the server implementation.
-            .set_redirect_uri(
-                RedirectUrl::new(format!("http://localhost:{}", callback_port))
-                    .expect("Invalid redirect URL"),
-            );
-
-        let http_client = reqwest::blocking::ClientBuilder::new()
-            // Following redirects opens the client up to SSRF vulnerabilities.
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .expect("Client should build");
-
-        // Generate the authorization URL to which we'll redirect the user.
-        let (authorize_url, csrf_state) = client
-            .authorize_url(CsrfToken::new_random)
-            // This example is requesting access to the user's public repos and private repos
-            .add_scope(Scope::new("repo".to_string()))
-            .url();
-
-        println!("Open this URL in your browser:\n{authorize_url}\n");
-        let (code, state) = {
-            // A very naive implementation of the redirect server.
-            let listener = TcpListener::bind(format!("localhost:{}", callback_port)).unwrap();
-
-            // The server will terminate itself after collecting the first code.
-            let Some(mut stream) = listener.incoming().flatten().next() else {
-                panic!("listener terminated without accepting a connection");
-            };
-
-            let mut reader = BufReader::new(&stream);
-
-            let mut request_line = String::new();
-            reader.read_line(&mut request_line).unwrap();
-
-            let redirect_url = request_line.split_whitespace().nth(1).unwrap();
-            let url = Url::parse(&("http://localhost".to_string() + redirect_url)).unwrap();
-
-            let code = url
-                .query_pairs()
-                .find(|(key, _)| key == "code")
-                .map(|(_, code)| AuthorizationCode::new(code.into_owned()))
-                .unwrap();
-
-            let state = url
-                .query_pairs()
-                .find(|(key, _)| key == "state")
-                .map(|(_, state)| CsrfToken::new(state.into_owned()))
-                .unwrap();
-
-            let message = "Go back to your terminal :)";
-            let response = format!(
-                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\n\r\n{}",
-                message.len(),
-                message
-            );
-            stream.write_all(response.as_bytes()).unwrap();
-
-            (code, state)
-        };
-
-        println!("Github returned the following code:\n{}\n", code.secret());
-        println!(
-            "Github returned the following state:\n{} (expected `{}`)\n",
-            state.secret(),
-            csrf_state.secret()
-        );
-
-        // Exchange the code with a token.
-        let token_res = client.exchange_code(code).request(&http_client).unwrap();
-
-        println!("Github returned the following token:\n{token_res:?}\n");
-
-        let access_token = token_res.access_token();
-
-        let mut callbacks = git2::RemoteCallbacks::new();
-        callbacks.credentials(move |url, username_from_url, _allowed_types| {
-            Cred::userpass_plaintext("oauth2", access_token.secret())
-        });
-
-        let repo = clone_flow(repo_url, repo_path, callbacks).unwrap();
-    }
 }

--- a/crates/moss-git/src/oauth.rs
+++ b/crates/moss-git/src/oauth.rs
@@ -1,0 +1,110 @@
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use git2::{Cred, RemoteCallbacks};
+use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope, TokenResponse, TokenUrl};
+use oauth2::basic::BasicClient;
+use oauth2::url::Url;
+
+pub struct OAuth {
+    auth_url: String,
+    token_url: String,
+    client_id: String,
+    client_secret: String,
+    callback_port: String,
+}
+
+impl OAuth {
+    pub fn new(auth_url: &str, token_url: &str, client_id: &str, client_secret: &str, callback_port: &str) -> OAuth {
+        OAuth {
+            auth_url: auth_url.to_string(),
+            token_url: token_url.to_string(),
+            client_id: client_id.to_string(),
+            client_secret: client_secret.to_string(),
+            callback_port: callback_port.to_string(),
+        }
+    }
+
+
+    pub fn flow(&self, remote_callbacks: &mut RemoteCallbacks) {
+        let auth_url = AuthUrl::new(self.auth_url.clone())
+            .expect("Invalid authorization endpoint URL");
+        let token_url = TokenUrl::new(self.token_url.clone())
+            .expect("Invalid token endpoint URL");
+
+        let client = BasicClient::new(ClientId::new(self.client_id.to_string()))
+            .set_client_secret(ClientSecret::new(self.client_secret.to_string()))
+            .set_auth_uri(auth_url)
+            .set_token_uri(token_url)
+            .set_redirect_uri(
+                RedirectUrl::new(format!("http://localhost:{}", self.callback_port.to_string()))
+                    .expect("Invalid redirect URL"),
+            );
+
+        // Generate the authorization URL to which we'll redirect the user.
+        let (authorize_url, csrf_state) = client
+            .authorize_url(CsrfToken::new_random)
+            // This example is requesting access to the user's public repos and private repos
+            .add_scope(Scope::new("repo".to_string()))
+            .url();
+
+        // TODO: Open a webview window for this url
+
+        println!("Open this URL in your browser:\n{authorize_url}\n");
+        let (code, state) = {
+            // A very naive implementation of the redirect server.
+            let listener = TcpListener::bind(format!("localhost:{}", self.callback_port.to_string())).unwrap();
+
+            // The server will terminate itself after collecting the first code.
+            let Some(mut stream) = listener.incoming().flatten().next() else {
+                panic!("listener terminated without accepting a connection");
+            };
+
+            let mut reader = BufReader::new(&stream);
+
+            let mut request_line = String::new();
+            reader.read_line(&mut request_line).unwrap();
+
+            // GET /?code=*** HTTP/1.1
+            let redirect_url = request_line.split_whitespace().nth(1).unwrap();
+            let url = Url::parse(&("http://localhost".to_string() + redirect_url)).unwrap();
+
+            let code = url
+                .query_pairs()
+                .find(|(key, _)| key == "code")
+                .map(|(_, code)| AuthorizationCode::new(code.into_owned()))
+                .unwrap();
+
+            let state = url
+                .query_pairs()
+                .find(|(key, _)| key == "state")
+                .map(|(_, state)| CsrfToken::new(state.into_owned()))
+                .unwrap();
+
+            // TODO: Once the code is received, the focus should switch back to the main application
+            let message = "Go back to your terminal :)";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\n\r\n{}",
+                message.len(),
+                message
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+
+            (code, state)
+        };
+
+        let http_client = reqwest::blocking::ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("Client should build");
+
+        // Exchange the code with a token.
+        let token_res = client.exchange_code(code).request(&http_client).unwrap();
+
+        let access_token = token_res.access_token().secret().to_owned();
+
+        remote_callbacks.credentials(move |url, username_from_url, _allowed_types| {
+            Cred::userpass_plaintext("oauth2", access_token.as_str())
+        });
+    }
+}

--- a/crates/moss-git/src/oauth.rs
+++ b/crates/moss-git/src/oauth.rs
@@ -1,7 +1,12 @@
+// https://datatracker.ietf.org/doc/html/rfc7636#section-1.1
+// https://datatracker.ietf.org/doc/html/rfc8252#section-7
+
+
+
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use git2::{Cred, RemoteCallbacks};
-use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope, TokenResponse, TokenUrl};
+use oauth2::{AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope, TokenResponse, TokenUrl};
 use oauth2::basic::BasicClient;
 use oauth2::url::Url;
 
@@ -10,17 +15,15 @@ pub struct OAuth {
     token_url: String,
     client_id: String,
     client_secret: String,
-    callback_port: String,
 }
 
 impl OAuth {
-    pub fn new(auth_url: &str, token_url: &str, client_id: &str, client_secret: &str, callback_port: &str) -> OAuth {
+    pub fn new(auth_url: &str, token_url: &str, client_id: &str, client_secret: &str) -> OAuth {
         OAuth {
             auth_url: auth_url.to_string(),
             token_url: token_url.to_string(),
             client_id: client_id.to_string(),
             client_secret: client_secret.to_string(),
-            callback_port: callback_port.to_string(),
         }
     }
 
@@ -31,20 +34,28 @@ impl OAuth {
         let token_url = TokenUrl::new(self.token_url.clone())
             .expect("Invalid token endpoint URL");
 
+        // Setting the port as 0 automatically assigns a free port
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let callback_port = listener.local_addr().unwrap().port();
+
         let client = BasicClient::new(ClientId::new(self.client_id.to_string()))
             .set_client_secret(ClientSecret::new(self.client_secret.to_string()))
             .set_auth_uri(auth_url)
             .set_token_uri(token_url)
             .set_redirect_uri(
-                RedirectUrl::new(format!("http://localhost:{}", self.callback_port.to_string()))
+                RedirectUrl::new(format!("http://127.0.0.1:{}", callback_port.to_string()))
                     .expect("Invalid redirect URL"),
             );
+
+        // https://datatracker.ietf.org/doc/html/rfc7636#section-1.1
+        let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
         // Generate the authorization URL to which we'll redirect the user.
         let (authorize_url, csrf_state) = client
             .authorize_url(CsrfToken::new_random)
             // This example is requesting access to the user's public repos and private repos
             .add_scope(Scope::new("repo".to_string()))
+            .set_pkce_challenge(pkce_challenge)
             .url();
 
         // TODO: Open a webview window for this url
@@ -52,7 +63,7 @@ impl OAuth {
         println!("Open this URL in your browser:\n{authorize_url}\n");
         let (code, state) = {
             // A very naive implementation of the redirect server.
-            let listener = TcpListener::bind(format!("localhost:{}", self.callback_port.to_string())).unwrap();
+
 
             // The server will terminate itself after collecting the first code.
             let Some(mut stream) = listener.incoming().flatten().next() else {
@@ -66,7 +77,7 @@ impl OAuth {
 
             // GET /?code=*** HTTP/1.1
             let redirect_url = request_line.split_whitespace().nth(1).unwrap();
-            let url = Url::parse(&("http://localhost".to_string() + redirect_url)).unwrap();
+            let url = Url::parse(&("http://127.0.0.1".to_string() + redirect_url)).unwrap();
 
             let code = url
                 .query_pairs()
@@ -98,8 +109,12 @@ impl OAuth {
             .build()
             .expect("Client should build");
 
-        // Exchange the code with a token.
-        let token_res = client.exchange_code(code).request(&http_client).unwrap();
+        // Exchange the code alongside with PKCE verifier with a token .
+        let token_res =
+            client
+                .exchange_code(code)
+                .set_pkce_verifier(pkce_verifier)
+                .request(&http_client).unwrap();
 
         let access_token = token_res.access_token().secret().to_owned();
 


### PR DESCRIPTION
Setting up demos for Git authentication/authorization, with test cases cloning a private repo using https and ssh. 
Implement a basic OAuth flow with PKCE for GitHub (and potentially other providers in the future) 
For GitLab, the git credential helper is already configured to provide OAuth like authentication options, so it's not necessary to manually run the OAuth flow.
(We will likely need some testing to make sure that everything works well under different OS)